### PR TITLE
Port documentation to IDF5 build flow

### DIFF
--- a/deploy.md
+++ b/deploy.md
@@ -289,7 +289,10 @@ esptool.py -p /dev/cu.usbserial-* --baud 230400 write_flash 0xf9000 versions1-pr
 ```
 - upload the ota-boot BETA program to the device that contains the private key
 ```
-make flash OTAVERSION=0.10.2 OTABETA=1
+idf.py set-target esp32
+idf.py menuconfig
+idf.py build OTAVERSION=0.10.2 OTABETA=1
+idf.py -p PORT flash monitor
 ```
 - setup wifi and select the ota-demo repo without pre-release checkbox  
 - create the 2 signature files next to the bin file and upload to github one by one  

--- a/main/main.c
+++ b/main/main.c
@@ -126,7 +126,7 @@ void ota_task(void *arg) {
             }
 */
             //if there is a newer version of ota-main...
-            if (ota_compare(ota_version,(char*)esp_app_get_description()->version)>0) { //set OTAVERSION when running make and match with github
+            if (ota_compare(ota_version,(char*)esp_app_get_description()->version)>0) { //set OTAVERSION when building (e.g. using idf.py) and match with GitHub
                 ota_get_hash(OTAREPO, ota_version, BOOTFILE, &signature);
                 if (ota_verify_signature(&signature)) break; //signature file is not signed by our key, ABORT
                 file_size=ota_get_file(OTAREPO,ota_version,BOOTFILE,BOOT0SECTOR);


### PR DESCRIPTION
## Summary
- switch deploy instructions from `make` to `idf.py`
- clarify build comment in `main.c`

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687139c9b6e48321997316a2f0660728