### PR TITLE
Port HomeKit OTA API to ESP‑IDF

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Embed the server root certificate into the final binary
 idf_build_get_property(project_dir PROJECT_DIR)
-idf_component_register(SRCS "main.c" "ota.c" "wifi_config.c" "form_urlencoded.c" "udplogger.c"
-                    INCLUDE_DIRS "."
+idf_component_register(
+    SRCS "main.c" "ota.c" "wifi_config.c" "form_urlencoded.c" "udplogger.c" "../homekit integration/ota-api.c"
+    INCLUDE_DIRS "." "../homekit integration"
 )


### PR DESCRIPTION
## Summary
- port `ota-api.c` to ESP-IDF APIs
- add HomeKit OTA source to build

## Testing
- `cmake ..` *(fails: missing ESP-IDF environment)*

------
https://chatgpt.com/codex/tasks/task_e_687234a123088321ae03f7d11610ab5e