### PR TITLE
Add OTA integration example using esp32-homekit

### DIFF
--- a/examples/homekit_led_ota/CMakeLists.txt
+++ b/examples/homekit_led_ota/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.16)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(homekit_led_ota)

--- a/examples/homekit_led_ota/main/CMakeLists.txt
+++ b/examples/homekit_led_ota/main/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "main.c" "ota-api.c"
+                       INCLUDE_DIRS "."
+                       REQUIRES esp32-homekit)

--- a/examples/homekit_led_ota/main/idf_component.yml
+++ b/examples/homekit_led_ota/main/idf_component.yml
@@ -1,0 +1,3 @@
+dependencies:
+  idf: ">=5.3"
+  achimpieters/esp32-homekit: "~1.4.1"

--- a/examples/homekit_led_ota/main/main.c
+++ b/examples/homekit_led_ota/main/main.c
@@ -1,0 +1,179 @@
+#include <stdio.h>
+#include <esp_wifi.h>
+#include <esp_event.h>
+#include <esp_log.h>
+#include <nvs_flash.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <driver/gpio.h>
+#include <homekit/homekit.h>
+#include <homekit/characteristics.h>
+#include "ota-api.h"
+
+#define CHECK_ERROR(x) do {                        \
+                esp_err_t __err_rc = (x);                  \
+                if (__err_rc != ESP_OK) {                  \
+                        ESP_LOGE("INFORMATION", "Error: %s", esp_err_to_name(__err_rc)); \
+                        handle_error(__err_rc);                \
+                }                                          \
+} while(0)
+
+void handle_error(esp_err_t err) {
+        if (err == ESP_ERR_WIFI_NOT_STARTED || err == ESP_ERR_WIFI_CONN) {
+                ESP_LOGI("INFORMATION", "Restarting WiFi...");
+                esp_wifi_stop();
+                esp_wifi_start();
+        } else {
+                ESP_LOGE("ERROR", "Critical error, restarting device...");
+                esp_restart();
+        }
+}
+
+void on_wifi_ready();
+
+static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data) {
+        if (event_base == WIFI_EVENT && (event_id == WIFI_EVENT_STA_START || event_id == WIFI_EVENT_STA_DISCONNECTED)) {
+                ESP_LOGI("INFORMATION", "Connecting to WiFi...");
+                esp_wifi_connect();
+        } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+                ESP_LOGI("INFORMATION", "WiFi connected, IP obtained");
+                on_wifi_ready();
+        }
+}
+
+static void wifi_init() {
+        CHECK_ERROR(esp_netif_init());
+        CHECK_ERROR(esp_event_loop_create_default());
+        esp_netif_create_default_wifi_sta();
+
+        CHECK_ERROR(esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &event_handler, NULL));
+        CHECK_ERROR(esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, &event_handler, NULL));
+
+        wifi_init_config_t wifi_init_config = WIFI_INIT_CONFIG_DEFAULT();
+        CHECK_ERROR(esp_wifi_init(&wifi_init_config));
+        CHECK_ERROR(esp_wifi_set_storage(WIFI_STORAGE_RAM));
+
+        wifi_config_t wifi_config = {
+                .sta = {
+                        .ssid = CONFIG_ESP_WIFI_SSID,
+                        .password = CONFIG_ESP_WIFI_PASSWORD,
+                        .threshold.authmode = WIFI_AUTH_WPA2_PSK,
+                },
+        };
+
+        CHECK_ERROR(esp_wifi_set_mode(WIFI_MODE_STA));
+        CHECK_ERROR(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config));
+        CHECK_ERROR(esp_wifi_start());
+}
+
+#define LED_GPIO CONFIG_ESP_LED_GPIO
+bool led_on = false;
+
+void led_write(bool on) {
+        gpio_set_level(LED_GPIO, on ? 1 : 0);
+}
+
+void gpio_init() {
+        gpio_reset_pin(LED_GPIO);
+        gpio_set_direction(LED_GPIO, GPIO_MODE_OUTPUT);
+        led_write(led_on);
+}
+
+void accessory_identify_task(void *args) {
+        for (int i = 0; i < 3; i++) {
+                for (int j = 0; j < 2; j++) {
+                        led_write(true);
+                        vTaskDelay(pdMS_TO_TICKS(100));
+                        led_write(false);
+                        vTaskDelay(pdMS_TO_TICKS(100));
+                }
+                vTaskDelay(pdMS_TO_TICKS(250));
+        }
+        led_write(led_on);
+        vTaskDelete(NULL);
+}
+
+void accessory_identify(homekit_value_t _value) {
+        ESP_LOGI("INFORMATION", "Accessory identify");
+        xTaskCreate(accessory_identify_task, "Accessory identify", configMINIMAL_STACK_SIZE, NULL, 2, NULL);
+}
+
+homekit_value_t led_on_get() {
+        return HOMEKIT_BOOL(led_on);
+}
+
+void led_on_set(homekit_value_t value) {
+        if (value.format != homekit_format_bool) {
+                ESP_LOGE("ERROR", "Invalid value format: %d", value.format);
+                return;
+        }
+        led_on = value.bool_value;
+        led_write(led_on);
+}
+
+#define DEVICE_NAME "HomeKit LED"
+#define DEVICE_MANUFACTURER "X"
+#define DEVICE_SERIAL "1"
+#define DEVICE_MODEL "Z"
+#define FW_VERSION "0.0.0"
+
+homekit_characteristic_t ota_trigger  = API_OTA_TRIGGER;
+homekit_characteristic_t name         = HOMEKIT_CHARACTERISTIC_(NAME, DEVICE_NAME);
+homekit_characteristic_t manufacturer = HOMEKIT_CHARACTERISTIC_(MANUFACTURER,  DEVICE_MANUFACTURER);
+homekit_characteristic_t serial       = HOMEKIT_CHARACTERISTIC_(SERIAL_NUMBER, DEVICE_SERIAL);
+homekit_characteristic_t model        = HOMEKIT_CHARACTERISTIC_(MODEL, DEVICE_MODEL);
+homekit_characteristic_t revision     = HOMEKIT_CHARACTERISTIC_(FIRMWARE_REVISION, FW_VERSION);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverride-init"
+homekit_accessory_t *accessories[] = {
+        HOMEKIT_ACCESSORY(.id = 1, .category = homekit_accessory_category_lighting, .services = (homekit_service_t*[]) {
+                HOMEKIT_SERVICE(ACCESSORY_INFORMATION, .characteristics = (homekit_characteristic_t*[]) {
+                        &name,
+                        &manufacturer,
+                        &serial,
+                        &model,
+                        &revision,
+                        &ota_trigger,
+                        HOMEKIT_CHARACTERISTIC(IDENTIFY, accessory_identify),
+                        NULL
+                }),
+                HOMEKIT_SERVICE(LIGHTBULB, .primary = true, .characteristics = (homekit_characteristic_t*[]) {
+                        HOMEKIT_CHARACTERISTIC(NAME, "HomeKit LED"),
+                        HOMEKIT_CHARACTERISTIC(ON, false, .getter = led_on_get, .setter = led_on_set),
+                        NULL
+                }),
+                NULL
+        }),
+        NULL
+};
+#pragma GCC diagnostic pop
+
+homekit_server_config_t config = {
+        .accessories = accessories,
+        .password = CONFIG_ESP_SETUP_CODE,
+        .setupId = CONFIG_ESP_SETUP_ID,
+};
+
+void on_wifi_ready() {
+        ESP_LOGI("INFORMATION", "Starting HomeKit server...");
+        int c_hash = ota_read_sysparam(&manufacturer.value.string_value,
+                                       &serial.value.string_value,
+                                       &model.value.string_value,
+                                       &revision.value.string_value);
+        config.accessories[0]->config_number = c_hash;
+        homekit_server_init(&config);
+}
+
+void app_main(void) {
+        esp_err_t ret = nvs_flash_init();
+        if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+                ESP_LOGW("WARNING", "NVS flash initialization failed, erasing...");
+                CHECK_ERROR(nvs_flash_erase());
+                ret = nvs_flash_init();
+        }
+        CHECK_ERROR(ret);
+
+        wifi_init();
+        gpio_init();
+}

--- a/examples/homekit_led_ota/main/ota-api.c
+++ b/examples/homekit_led_ota/main/ota-api.c
@@ -1,0 +1,134 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "esp_mac.h"
+#include "esp_system.h"
+#include "esp_timer.h"
+#include "esp_log.h"
+#include "esp_check.h"
+#include "nvs.h"
+#include "ota.h"
+
+// the first function is the ONLY thing needed for a repo to support ota after having started with ota-boot
+// in ota-boot the user gets to set the wifi and the repository details and it then installs the ota-main binary
+
+extern nvs_handle_t lcm_handle;
+static const char *TAG = "ota-api";
+
+// Trigger the OTA process and restart into the temporary image
+void ota_update(void *arg) {  //arg not used
+    ota_temp_boot();
+    esp_restart();
+}
+
+// Read OTA related parameters from NVS and compute HomeKit configuration hash
+unsigned int  ota_read_sysparam(char **manufacturer, char **serial,
+                                char **model, char **revision)
+{
+    if (!manufacturer || !serial || !model || !revision) {
+        ESP_LOGE(TAG, "invalid argument");
+        return 0;
+    }
+
+    size_t size;
+    char *value;
+
+    esp_err_t err = nvs_get_str(lcm_handle, "ota_repo", NULL, &size);
+    if (err == ESP_OK) {
+        value = malloc(size);
+        if (!value) {
+            ESP_LOGE(TAG, "no memory for repo");
+            return 0;
+        }
+        err = nvs_get_str(lcm_handle, "ota_repo", value, &size);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "nvs get repo failed: %s", esp_err_to_name(err));
+            free(value);
+            return 0;
+        }
+        char *slash = strchr(value, '/');
+        if (slash) {
+            *slash = '\0';
+        }
+        *manufacturer = value;
+        *model = slash ? slash + 1 : value + strlen(value);
+    } else {
+        *manufacturer = "manuf_unknown";
+        *model = "model_unknown";
+    }
+
+    err = nvs_get_str(lcm_handle, "ota_version", NULL, &size);
+    if (err == ESP_OK) {
+        value = malloc(size);
+        if (!value) {
+            ESP_LOGE(TAG, "no memory for version");
+            return 0;
+        }
+        err = nvs_get_str(lcm_handle, "ota_version", value, &size);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "nvs get version failed: %s", esp_err_to_name(err));
+            free(value);
+            return 0;
+        }
+        *revision = value;
+    } else {
+        *revision = "0.0.0";
+    }
+
+    uint8_t mac_addr[6];
+    esp_read_mac(mac_addr, ESP_MAC_WIFI_STA);
+    *serial = malloc(18);
+    if (!*serial) {
+        ESP_LOGE(TAG, "No memory for serial");
+        return 0;
+    }
+    snprintf(*serial, 18, "%02X:%02X:%02X:%02X:%02X:%02X", mac_addr[0], mac_addr[1], mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
+
+    unsigned int c_hash = 0;
+    char version[16];
+    char *rev = version;
+    char *dot;
+    strncpy(rev, *revision, sizeof(version));
+    if ((dot = strchr(rev, '.'))) {
+        *dot = 0;
+        c_hash = atoi(rev);
+        rev = dot + 1;
+    }
+    if ((dot = strchr(rev, '.'))) {
+        *dot = 0;
+        c_hash = c_hash * 1000 + atoi(rev);
+        rev = dot + 1;
+    }
+    c_hash = c_hash * 1000 + atoi(rev);
+    ESP_LOGI(TAG, "manuf='%s' serial='%s' model='%s' revision='%s' c#=%d", *manufacturer, *serial, *model, *revision, c_hash);
+    return c_hash;
+}
+
+
+
+
+#include <homekit/characteristics.h>
+
+static esp_timer_handle_t update_timer;
+static void update_timer_cb(void* arg) {
+    ota_update(arg);
+}
+
+void ota_set(homekit_value_t value) {
+    if (value.format != homekit_format_bool) {
+        ESP_LOGW(TAG, "Invalid ota-value format: %d", value.format);
+        return;
+    }
+    if (value.bool_value) {
+        // Provide user feedback via identify routine and delay reboot
+        if (!update_timer) {
+            const esp_timer_create_args_t args = {
+                .callback = &update_timer_cb,
+                .name = "ota_update"
+            };
+            esp_timer_create(&args, &update_timer);
+        }
+        esp_timer_start_once(update_timer, 500000); //500ms
+    }
+}

--- a/examples/homekit_led_ota/main/ota-api.h
+++ b/examples/homekit_led_ota/main/ota-api.h
@@ -1,0 +1,30 @@
+#ifndef __HOMEKIT_CUSTOM_CHARACTERISTICS__
+#define __HOMEKIT_CUSTOM_CHARACTERISTICS__
+
+#define HOMEKIT_CUSTOM_UUID(value) (value "-0e36-4a42-ad11-745a73b84f2b")
+
+#define HOMEKIT_SERVICE_CUSTOM_SETUP HOMEKIT_CUSTOM_UUID("000000FF")
+
+#define HOMEKIT_CHARACTERISTIC_CUSTOM_OTA_TRIGGER HOMEKIT_CUSTOM_UUID("F0000001")
+#define HOMEKIT_DECLARE_CHARACTERISTIC_CUSTOM_OTA_TRIGGER(_value, ...) \
+    .type = HOMEKIT_CHARACTERISTIC_CUSTOM_OTA_TRIGGER, \
+    .description = "}FirmwareUpdate", \
+    .format = homekit_format_bool, \
+    .permissions = homekit_permissions_paired_read \
+    | homekit_permissions_paired_write \
+    | homekit_permissions_notify, \
+    .value = HOMEKIT_BOOL_(_value), \
+    ##__VA_ARGS__
+
+unsigned int ota_read_sysparam(char **manufacturer, char **serial,
+                               char **model, char **revision);
+
+// Trigger OTA update using previously saved settings
+void ota_update(void *arg);
+
+// HomeKit characteristic setter to initiate OTA update
+void ota_set(homekit_value_t value);
+
+#define API_OTA_TRIGGER HOMEKIT_CHARACTERISTIC_(CUSTOM_OTA_TRIGGER, false, .setter=ota_set)
+
+#endif


### PR DESCRIPTION
## Summary
- create `examples/homekit_led_ota` demonstrating OTA integration
- include `ota-api.c` and `ota-api.h` next to `main.c`
- register new component with CMake and `idf_component.yml`
- implement OTA trigger characteristic and HomeKit config hash

## Testing
- `idf.py set-target esp32` *(fails: cannot reach component registry)*

------
https://chatgpt.com/codex/tasks/task_e_68727046c1e08321aeeff896777b5ea9